### PR TITLE
Add test cases for high data need and unsupported service

### DIFF
--- a/dev/010_custom_agent.md
+++ b/dev/010_custom_agent.md
@@ -3,9 +3,11 @@ This release covers Task 01: Custom agent and tool `docs/tasks/0301_custom_agent
 
 ## Session logs
 
+
 session logs are timestamped to Singapore timezone in reverse chronological order, with latest entries at the top, and earlier entries at the bottom.
 
-### Roaming data plan [Codex] test cases 2025-07-21 <HH>:<MM>
+### Roaming data plan [Codex] test cases 2025-07-21 15:34
+- add tests for high data need filtering and unsupported service type
 
 
 ### Roaming data plan [Developer] test cases Codex prompt 2025-07-21 15:33

--- a/test.py
+++ b/test.py
@@ -56,7 +56,44 @@ class TestRoamingPlanRecommender(unittest.TestCase):
     
         top_plan = plans[0]
         is_expected_error = 'no zone found' in top_plan.get('error', '').lower()
-        self.assertTrue(is_expected_error, f"expected 'no zone found' error, got {top_plan}") 
+        self.assertTrue(is_expected_error, f"expected 'no zone found' error, got {top_plan}")
+
+    def test_high_data_need_filters(self):
+        plans = self.recommender.recommend(
+            destination="Thailand",
+            duration_days=7,
+            service_type="data",
+            data_needed_gb=20.0
+        )
+
+        self.assertTrue(plans, "Expected at least one plan, got none.")
+
+        top_plan = plans[0]
+
+        expected_plan = {
+            "zone": 1,
+            "duration_days": 7,
+            "data_gb": 6.5,
+            "price_sgd": 6.0,
+            "rate_data_per_10kb": 0.01,
+            "rate_calls_outgoing_per_min": 0.29,
+            "rate_calls_incoming_per_min": 0.0,
+            "rate_per_sms": 0.1,
+        }
+
+        for key, expected_value in expected_plan.items():
+            self.assertEqual(top_plan.get(key), expected_value,
+                             f"Mismatch in {key}: expected '{expected_value}', got '{top_plan.get(key)}'")
+
+    def test_unsupported_service_type(self):
+        plans = self.recommender.recommend(
+            destination="Malaysia",
+            duration_days=1,
+            service_type="fax",
+            data_needed_gb=1
+        )
+
+        self.assertEqual(plans, [], "Expected empty result for unsupported service type")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- extend test suite with high data need and unsupported service type cases
- record the update in the release notes

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q` *(fails: AttributeError in log_test.py)*

------
https://chatgpt.com/codex/tasks/task_e_687ded197b888323ba9e3c9cb92538cb