### PR TITLE
Add placeholder tests for RoamingPlanAgent

### DIFF
--- a/dev/010_custom_agent.md
+++ b/dev/010_custom_agent.md
@@ -6,7 +6,11 @@ This release covers Task 01: Custom agent and tool `docs/tasks/0301_custom_agent
 
 session logs are timestamped to Singapore timezone in reverse chronological order, with latest entries at the top, and earlier entries at the bottom.
 
-### Roaming data plan [Codex] RoamingPlanAgent recommend agent class test cases 2025-07-21 <>:<MM>
+### Roaming data plan [Codex] RoamingPlanAgent recommend agent class test cases 2025-07-21 17:30
+
+Implemented skeleton unittest class `TestRoamingPlanAgent` in `test.py` with
+placeholder tests for each scenario listed in the design document. All tests are
+skipped until the future agent implementation is available.
 
 
 ### Roaming data plan [Developer] Codex prompt RoamingPlanAgent recommend agent test cases 2025-07-21 17:05

--- a/test.py
+++ b/test.py
@@ -98,10 +98,81 @@ class TestRoamingPlanRecommender(unittest.TestCase):
         if plans:
             plan = plans[0]
             self.assertIn(
-                'unsupported service type', 
-                plan.get('error', '').lower(), 
+                'unsupported service type',
+                plan.get('error', '').lower(),
                 f"Expected error unsupported service type, got {plan}"
             )
+
+
+class TestRoamingPlanAgent(unittest.TestCase):
+    """Design placeholder tests for the conversational Recommendation Agent.
+
+    These tests outline expected behaviours described in the design document.
+    They are marked as skipped until the RoamingPlanAgent implementation is
+    available.  Each test demonstrates the intended invocation pattern using an
+    ``agent.step`` interface that returns a structured dictionary with plan
+    choices or error details.
+    """
+
+    def setUp(self):
+        # Placeholder agent stub. In future this should instantiate the real
+        # RoamingPlanAgent with access to RoamingPlanRecommender.
+        self.agent = None
+
+    @unittest.skip("RoamingPlanAgent not implemented")
+    def test_valid_query(self):
+        """Valid query returns ranked plan options."""
+        user_msg = "I'm going to Japan for 3 days and need 2GB of data."
+        # response = self.agent.step(user_msg)
+        # self.assertEqual(len(response['plans']), 3)
+        # self.assertFalse(response.get('error'))
+
+    @unittest.skip("RoamingPlanAgent not implemented")
+    def test_invalid_country_retry(self):
+        """Unknown country should trigger validation feedback."""
+        user_msg = "I'll be in Blorkistan."
+
+    @unittest.skip("RoamingPlanAgent not implemented")
+    def test_near_match_country(self):
+        """Agent clarifies close country names."""
+        user_msg = "I'm traveling to Korea."
+
+    @unittest.skip("RoamingPlanAgent not implemented")
+    def test_plan_query_prompt_duration_and_amount(self):
+        """Agent asks for missing duration/data when only destination given."""
+        user_msg = "Need data for Thailand."
+
+    @unittest.skip("RoamingPlanAgent not implemented")
+    def test_non_numeric_near_duration(self):
+        user_msg = "I'll be there for a few moons."
+
+    @unittest.skip("RoamingPlanAgent not implemented")
+    def test_non_numeric_nonsense_duration(self):
+        user_msg = "I'll be there for a few spoons."
+
+    @unittest.skip("RoamingPlanAgent not implemented")
+    def test_out_of_scope_query(self):
+        user_msg = "How's the weather in Tokyo?"
+
+    @unittest.skip("RoamingPlanAgent not implemented")
+    def test_high_data_demand(self):
+        user_msg = "Going to Malaysia, need 100GB for 2 weeks."
+
+    @unittest.skip("RoamingPlanAgent not implemented")
+    def test_sms_only_request(self):
+        user_msg = "Going to Vietnam, only need SMS for 5 days."
+
+    @unittest.skip("RoamingPlanAgent not implemented")
+    def test_purchase_rejection(self):
+        user_msg = "No thanks"  # after plan shown
+
+    @unittest.skip("RoamingPlanAgent not implemented")
+    def test_user_confirms_plan(self):
+        user_msg = "I'll take option 2"
+
+    @unittest.skip("RoamingPlanAgent not implemented")
+    def test_unexpected_utterance_mid_flow(self):
+        user_msg = "Nevermind, show me movie times"
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add skeleton `TestRoamingPlanAgent` class with skipped tests for design scenarios
- log update in release notes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e02714b7c8323a522579a5e1a5002