### PR TITLE
Implement RoamingPlanAgent

### DIFF
--- a/dev/010_custom_agent.md
+++ b/dev/010_custom_agent.md
@@ -5,9 +5,13 @@ This release covers Task 01: Custom agent and tool `docs/tasks/0301_custom_agent
 
 session logs are timestamped to Singapore timezone in reverse chronological order, with latest entries at the top, and earlier entries at the bottom.
 
-### Roaming data plan [Codex] RoamingPlanAgent 2025-07-21 <HH>:<MM>
+### Roaming data plan [Codex] RoamingPlanAgent 2025-07-21 22:04
 
-
+- Implemented `RoamingPlanAgent` with stateful `step` method parsing destination,
+  duration, data amount and service type.
+- Integrated agent with `RoamingPlanRecommender` and basic plan selection logic.
+- Updated `test.py` to exercise valid query, invalid country, high data demand
+  and plan confirmation scenarios without skips.
 ### Roaming data plan [Developer] Codex prompt RoamingPlanAgent 2025-07-21 22:00
 for context, refer to 
  - Roaming Plan Agent design doc `/docs/0301_custom_agent.md` and release doc `dev/010_custom_eagent.md`

--- a/recommend_agent/chat_agent.py
+++ b/recommend_agent/chat_agent.py
@@ -1,51 +1,137 @@
-# recommend_agent/tools.py
+from __future__ import annotations
+import re
 import pandas as pd
-from langchain.tools import tool
+from base import BaseHandler
 from .recommend import RoamingPlanRecommender
 
 
-class RoamingPlanAgent():
-    def __init__(self):
-        pass
+class RoamingPlanAgent(BaseHandler):
+    """Lightweight conversational agent for roaming plan queries."""
 
+    def __init__(self, recommender: RoamingPlanRecommender | None = None):
+        self.recommender = recommender or RoamingPlanRecommender()
+        # ensure database is available
+        self.recommender.db_build()
+        self._load_destinations()
+        self.reset()
+        super().__init__()
 
-@tool
-def plans_db_tool(destination: str, duration: str = "1 day", service_type: str = "data") -> str:
-    """
-    Recommends the top 3 roaming plans for a given destination, duration, and service type.
-    Accepts:
-      - destination: country name
-      - duration: pass duration (e.g., "1 day", "3 days")
-      - service_type: one of "data", "calls", or "sms"
-    Returns:
-      - A summary of the top 3 matching plans with pros/cons.
-    """
-    try:
-        candidates = df[df['Destination'].str.lower() == destination.lower()]
-        candidates = candidates[candidates['Data_Pass_Validity'].str.lower() == duration.lower()]
-        if candidates.empty:
-            return f"No plans found for {destination} with duration {duration}."
+    def _load_destinations(self):
+        try:
+            df = pd.read_csv('data/destination.csv')
+            self._dest_lookup = {c.lower(): c for c in df['country'].tolist()}
+        except Exception:
+            self._dest_lookup = {}
 
-        results = []
-        for _, row in candidates.iterrows():
-            score = 0
-            if service_type == "data":
-                score = float(row['Data_Pass_Data'].replace("GB", "").replace("MB", ""))
-            elif service_type == "calls":
-                score = -float(row['Pay_Per_Use_Call_Outgoing'].replace("S$", "").split("/")[0])
-            elif service_type == "sms":
-                score = -float(row['Pay_Per_Use_SMS'].replace("S$", "").split("/")[0])
+    def reset(self):
+        """Clear conversation state."""
+        self.state = {
+            'destination': None,
+            'duration_days': None,
+            'service_type': 'data',
+            'data_needed_gb': None,
+            'plans': [],
+            'selected_plan': None,
+        }
 
-            results.append((score, row))
+    # ------------------------------------------------------------------ parsing
+    def _parse_destination(self, text: str) -> str | None:
+        match = re.search(r'(?:to|in) ([A-Za-z ,\'\-]+)', text)
+        if match:
+            dest = match.group(1).strip()
+            return dest
+        return None
 
-        top3 = sorted(results, key=lambda x: -x[0])[:3]
-        response = ""
-        for i, (_, plan) in enumerate(top3, 1):
-            response += (
-                f"\n{i}. Zone: {plan['Zone']}, Destination: {plan['Destination']}, "
-                f"Price: {plan['Data_Pass_Price']}, Data: {plan['Data_Pass_Data']}, "
-                f"Calls: {plan['Pay_Per_Use_Call_Outgoing']}, SMS: {plan['Pay_Per_Use_SMS']}"
-            )
-        return response.strip()
-    except Exception as e:
-        return f"Error processing request: {str(e)}"
+    def _canonical_destination(self, dest: str) -> str | None:
+        dest_lc = dest.lower()
+        if dest_lc in self._dest_lookup:
+            return self._dest_lookup[dest_lc]
+        if dest_lc == 'korea':
+            return 'Korea, Republic of'
+        return None
+
+    def _parse_duration(self, text: str) -> int | None:
+        m = re.search(r'(\d+)\s*(day|days|week|weeks|month|months)', text)
+        if m:
+            num = int(m.group(1))
+            unit = m.group(2)
+            if unit.startswith('week'):
+                return num * 7
+            if unit.startswith('month'):
+                return num * 30
+            return num
+        return None
+
+    def _parse_data_amount(self, text: str) -> float | None:
+        m = re.search(r'(\d+(?:\.\d+)?)\s*gb', text.lower())
+        if m:
+            return float(m.group(1))
+        return None
+
+    def _parse_service_type(self, text: str) -> str | None:
+        txt = text.lower()
+        if 'sms' in txt:
+            return 'sms'
+        if 'call' in txt:
+            return 'calls'
+        if 'data' in txt:
+            return 'data'
+        return None
+
+    # ---------------------------------------------------------------- interaction
+    def step(self, user_message: str) -> dict:
+        """Process one user message and return agent response state."""
+        msg = user_message.strip()
+
+        dest_raw = self._parse_destination(msg)
+        if dest_raw:
+            self.state['destination'] = dest_raw
+
+        dur = self._parse_duration(msg)
+        if dur:
+            self.state['duration_days'] = dur
+
+        data_needed = self._parse_data_amount(msg)
+        if data_needed is not None:
+            self.state['data_needed_gb'] = data_needed
+
+        service = self._parse_service_type(msg)
+        if service:
+            self.state['service_type'] = service
+
+        # plan selection
+        opt = re.search(r'option\s*(\d+)', msg.lower())
+        if opt and self.state.get('plans'):
+            idx = int(opt.group(1)) - 1
+            if 0 <= idx < len(self.state['plans']):
+                self.state['selected_plan'] = self.state['plans'][idx]
+                return {'selected_plan': self.state['selected_plan']}
+
+        if self.state['destination']:
+            canonical = self._canonical_destination(self.state['destination'])
+            if not canonical:
+                err = f'no zone found for {self.state["destination"]}'
+                self.state['plans'] = []
+                return {'plans': [], 'error': err}
+            self.state['destination'] = canonical
+
+        # gather missing info prompts
+        if self.state['destination'] is None:
+            return {'prompt': 'Which country will you visit?'}
+        if self.state['duration_days'] is None:
+            return {'prompt': 'How long is your trip in days?'}
+        if self.state['service_type'] == 'data' and self.state['data_needed_gb'] is None:
+            return {'prompt': 'How much data do you need in GB?'}
+
+        # ready to recommend
+        plans = self.recommender.recommend(
+            destination=self.state['destination'],
+            duration_days=self.state['duration_days'],
+            service_type=self.state['service_type'],
+            data_needed_gb=self.state['data_needed_gb'],
+        )
+        self.state['plans'] = plans
+        if plans and 'error' in plans[0]:
+            return {'plans': [], 'error': plans[0]['error']}
+        return {'plans': plans}
+

--- a/test.py
+++ b/test.py
@@ -120,12 +120,14 @@ class TestRoamingPlanAgent(unittest.TestCase):
         # RoamingPlanAgent with access to RoamingPlanRecommender.
         cls.agent = RoamingPlanAgent()
 
-    @unittest.skip("RoamingPlanAgent not implemented")
     def test_valid_query(self):
         """Valid query returns ranked plan options."""
         user_msg = "I'm going to Japan for 3 days and need 2GB of data."
+        self.agent.reset()
+        response = self.agent.step(user_msg)
+        self.assertIn("plans", response)
+        self.assertGreater(len(response["plans"]), 0)
 
-    @unittest.skip("RoamingPlanAgent not implemented")
     def test_invalid_country(self):
         self.agent.reset()
         response = self.agent.step("I'll be in Blorkistan.")
@@ -156,7 +158,6 @@ class TestRoamingPlanAgent(unittest.TestCase):
     def test_out_of_scope_query(self):
         user_msg = "How's the weather in Tokyo?"
 
-    @unittest.skip("RoamingPlanAgent not implemented")
     def test_high_data_demand_real(self):
         user_msg = "Going to Malaysia, need 100GB for 2 weeks."
         at_least_plan_gb = 5 # we can adjust this threshold based on plan catalog
@@ -171,7 +172,7 @@ class TestRoamingPlanAgent(unittest.TestCase):
 
         # At least one plan should meet or exceed available high data (even if not 100GB)
         max_plan_data = max(plan["data_gb"] for plan in response["plans"])
-        self.assertGreaterEqual(max_plan_data, at_least_plan_gb, f'expected to find plan at least {at_least_plan_gb} GB. found only {max_plan_data}')  
+        self.assertGreaterEqual(max_plan_data, at_least_plan_gb, f'expected to find plan at least {at_least_plan_gb} GB. found only {max_plan_data}')
 
     @unittest.skip("RoamingPlanAgent not implemented")
     def test_high_data_demand(self):
@@ -185,9 +186,13 @@ class TestRoamingPlanAgent(unittest.TestCase):
     def test_purchase_rejection(self):
         user_msg = "No thanks"  # after plan shown
 
-    @unittest.skip("RoamingPlanAgent not implemented")
     def test_user_confirms_plan(self):
-        user_msg = "I'll take option 2"
+        self.agent.reset()
+        first = self.agent.step("I'm going to Japan for 3 days and need 2GB of data.")
+        self.assertIn("plans", first)
+        self.assertGreater(len(first["plans"]), 0)
+        confirm = self.agent.step("I'll take option 1")
+        self.assertEqual(confirm.get("selected_plan"), first["plans"][0])
 
     @unittest.skip("RoamingPlanAgent not implemented")
     def test_unexpected_utterance_mid_flow(self):
@@ -196,3 +201,4 @@ class TestRoamingPlanAgent(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+


### PR DESCRIPTION
## Summary
- implement `RoamingPlanAgent` with basic parsing/state and tool integration
- flesh out tests for valid queries, invalid destination, high data demand and plan confirmation
- record implementation log in release notes

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e47d74fd88323aad3aa9341657f44